### PR TITLE
Add the dense box algorithm

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -1,0 +1,254 @@
+
+#ifndef CVECTOR_H_
+#define CVECTOR_H_
+
+#include <assert.h> /* for assert */
+#include <stdlib.h> /* for malloc/realloc/free */
+#include <string.h> /* for memcpy/memmove */
+
+/* cvector heap implemented using C library malloc() */
+
+/* in case C library malloc() needs extra protection,
+ * allow these defines to be overridden.
+ */
+#ifndef cvector_clib_free
+#define cvector_clib_free free
+#endif
+#ifndef cvector_clib_malloc
+#define cvector_clib_malloc malloc
+#endif
+#ifndef cvector_clib_calloc
+#define cvector_clib_calloc calloc
+#endif
+#ifndef cvector_clib_realloc
+#define cvector_clib_realloc realloc
+#endif
+
+/**
+ * @brief cvector_vector_type - The vector type used in this library
+ */
+#define cvector_vector_type(type) type *
+
+/**
+ * @brief cvector_capacity - gets the current capacity of the vector
+ * @param vec - the vector
+ * @return the capacity as a size_t
+ */
+#define cvector_capacity(vec) \
+    ((vec) ? ((size_t *)(vec))[-1] : (size_t)0)
+
+/**
+ * @brief cvector_size - gets the current size of the vector
+ * @param vec - the vector
+ * @return the size as a size_t
+ */
+#define cvector_size(vec) \
+    ((vec) ? ((size_t *)(vec))[-2] : (size_t)0)
+
+/**
+ * @brief cvector_empty - returns non-zero if the vector is empty
+ * @param vec - the vector
+ * @return non-zero if empty, zero if non-empty
+ */
+#define cvector_empty(vec) \
+    (cvector_size(vec) == 0)
+
+/**
+ * @brief cvector_reserve - Requests that the vector capacity be at least enough
+ * to contain n elements. If n is greater than the current vector capacity, the
+ * function causes the container to reallocate its storage increasing its
+ * capacity to n (or greater).
+ * @param vec - the vector
+ * @param n - Minimum capacity for the vector.
+ * @return void
+ */
+#define cvector_reserve(vec, capacity)         \
+    do {                                       \
+        size_t cv_cap = cvector_capacity(vec); \
+        if (cv_cap < (capacity)) {             \
+            cvector_grow((vec), (capacity));   \
+        }                                      \
+    } while (0)
+
+/**
+ * @brief cvector_erase - removes the element at index i from the vector
+ * @param vec - the vector
+ * @param i - index of element to remove
+ * @return void
+ */
+#define cvector_erase(vec, i)                                                              \
+    do {                                                                                   \
+        if ((vec)) {                                                                       \
+            const size_t cv_sz = cvector_size(vec);                                        \
+            if ((i) < cv_sz) {                                                             \
+                cvector_set_size((vec), cv_sz - 1);                                        \
+                memmove((vec) + (i), (vec) + (i) + 1, sizeof(*(vec)) * (cv_sz - 1 - (i))); \
+            }                                                                              \
+        }                                                                                  \
+    } while (0)
+
+/**
+ * @brief cvector_free - frees all memory associated with the vector
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_free(vec)                        \
+    do {                                         \
+        if ((vec)) {                             \
+            size_t *p1 = &((size_t *)(vec))[-2]; \
+            cvector_clib_free(p1);               \
+        }                                        \
+    } while (0)
+
+/**
+ * @brief cvector_begin - returns an iterator to first element of the vector
+ * @param vec - the vector
+ * @return a pointer to the first element (or NULL)
+ */
+#define cvector_begin(vec) \
+    (vec)
+
+/**
+ * @brief cvector_end - returns an iterator to one past the last element of the vector
+ * @param vec - the vector
+ * @return a pointer to one past the last element (or NULL)
+ */
+#define cvector_end(vec) \
+    ((vec) ? &((vec)[cvector_size(vec)]) : NULL)
+
+/* user request to use logarithmic growth algorithm */
+#ifdef CVECTOR_LOGARITHMIC_GROWTH
+
+/**
+ * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
+ * size is increased by multiplication of 2
+ * @param size - current size
+ * @return size after next vector grow
+ */
+#define cvector_compute_next_grow(size) \
+    ((size) ? ((size) << 1) : 1)
+
+#else
+
+/**
+ * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
+ * size is increased by 1
+ * @param size - current size
+ * @return size after next vector grow
+ */
+#define cvector_compute_next_grow(size) \
+    ((size) + 1)
+
+#endif /* CVECTOR_LOGARITHMIC_GROWTH */
+
+/**
+ * @brief cvector_push_back - adds an element to the end of the vector
+ * @param vec - the vector
+ * @param value - the value to add
+ * @return void
+ */
+#define cvector_push_back(vec, value)                               \
+    do {                                                            \
+        size_t cv_cap = cvector_capacity(vec);                      \
+        if (cv_cap <= cvector_size(vec)) {                          \
+            cvector_grow((vec), cvector_compute_next_grow(cv_cap)); \
+        }                                                           \
+        vec[cvector_size(vec)] = (value);                           \
+        cvector_set_size((vec), cvector_size(vec) + 1);             \
+    } while (0)
+
+/**
+ * @brief cvector_insert - insert element at position pos to the vector
+ * @param vec - the vector
+ * @param pos - position in the vector where the new elements are inserted.
+ * @param val - value to be copied (or moved) to the inserted elements.
+ * @return void
+ */
+#define cvector_insert(vec, pos, val)                                                                      \
+    do {                                                                                                   \
+        if (cvector_capacity(vec) <= cvector_size(vec) + 1) {                                              \
+            cvector_grow((vec), cvector_compute_next_grow(cvector_capacity((vec))));                       \
+        }                                                                                                  \
+        if (pos < cvector_size(vec)) {                                                                     \
+            memmove((vec) + (pos) + 1, (vec) + (pos), sizeof(*(vec)) * ((cvector_size(vec) + 1) - (pos))); \
+        }                                                                                                  \
+        (vec)[(pos)] = (val);                                                                              \
+        cvector_set_size((vec), cvector_size(vec) + 1);                                                    \
+    } while (0)
+
+/**
+ * @brief cvector_pop_back - removes the last element from the vector
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_pop_back(vec)                           \
+    do {                                                \
+        cvector_set_size((vec), cvector_size(vec) - 1); \
+    } while (0)
+
+/**
+ * @brief cvector_copy - copy a vector
+ * @param from - the original vector
+ * @param to - destination to which the function copy to
+ * @return void
+ */
+#define cvector_copy(from, to)                                          \
+    do {                                                                \
+        if ((from)) {                                                   \
+            cvector_grow(to, cvector_size(from));                       \
+            cvector_set_size(to, cvector_size(from));                   \
+            memcpy((to), (from), cvector_size(from) * sizeof(*(from))); \
+        }                                                               \
+    } while (0)
+
+/**
+ * @brief cvector_set_capacity - For internal use, sets the capacity variable of the vector
+ * @param vec - the vector
+ * @param size - the new capacity to set
+ * @return void
+ */
+#define cvector_set_capacity(vec, size)     \
+    do {                                    \
+        if ((vec)) {                        \
+            ((size_t *)(vec))[-1] = (size); \
+        }                                   \
+    } while (0)
+
+/**
+ * @brief cvector_set_size - For internal use, sets the size variable of the vector
+ * @param vec - the vector
+ * @param size - the new capacity to set
+ * @return void
+ */
+#define cvector_set_size(vec, size)         \
+    do {                                    \
+        if ((vec)) {                        \
+            ((size_t *)(vec))[-2] = (size); \
+        }                                   \
+    } while (0)
+
+/**
+ * @brief cvector_grow - For internal use, ensures that the vector is at least <count> elements big
+ * @param vec - the vector
+ * @param count - the new capacity to set
+ * @return void
+ */
+#define cvector_grow(vec, count)                                              \
+    do {                                                                      \
+        const size_t cv_sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
+        if ((vec)) {                                                          \
+            size_t *cv_p1 = &((size_t *)(vec))[-2];                           \
+            size_t *cv_p2 = cvector_clib_realloc(cv_p1, (cv_sz));             \
+            assert(cv_p2);                                                    \
+            (vec) = (void *)(&cv_p2[2]);                                      \
+            cvector_set_capacity((vec), (count));                             \
+        } else {                                                              \
+            size_t *cv_p = cvector_clib_malloc(cv_sz);                        \
+            assert(cv_p);                                                     \
+            (vec) = (void *)(&cv_p[2]);                                       \
+            cvector_set_capacity((vec), (count));                             \
+            cvector_set_size((vec), 0);                                       \
+        }                                                                     \
+    } while (0)
+
+#endif /* CVECTOR_H_ */

--- a/dbscan.c
+++ b/dbscan.c
@@ -432,7 +432,34 @@ void dense_box(void *args)
             cvector_push_back(queue, merged[j]);
         }
 
-        // TODO: Continue merge with current label value and cells on queue.
+        // Continue merge using queue.
+        j = cvector_size(queue);
+        while (j > 0)
+        {
+            // Dequeue.
+            int focal = queue[0];
+            cvector_erase(queue, 0);
+            j -= 1;
+
+            // Update arguments for merge_dense_boxes.
+            args_merge_dense_boxes.focal = focal;
+            args_merge_dense_boxes.label = label;
+
+            // Merge surrounding dense boxes.
+            merged_count = merge_dense_boxes((void *)&args_merge_dense_boxes);
+
+            if (merged_count == 0)
+            {
+                continue;
+            }
+
+            // Queue merged dense boxes.
+            for (int k = 0; k < merged_count; k++)
+            {
+                cvector_push_back(queue, merged[k]);
+                j += 1;
+            }
+        }
     }
 
     // Free heap memory.

--- a/dbscan.c
+++ b/dbscan.c
@@ -32,6 +32,7 @@ struct args_get_neighbors
     struct point *points;
 };
 
+void create_grid(struct point *points);
 void create_points(struct point *points);
 void dbscan(void *args);
 int get_neighbors(void *args);
@@ -64,6 +65,10 @@ int main(int argc, char *argv[])
     }
     fclose(file_pointer);
 
+    create_grid(points);
+
+    // TODO: Run dense box algorithm.
+
     // Package arguments for dbscan.
     struct args_dbscan args = {
         .epsilon = epsilon,
@@ -84,6 +89,41 @@ int main(int argc, char *argv[])
     fclose(file_pointer);
 
     return 0;
+}
+
+void create_grid(struct point *points)
+{
+    double min_x;
+    double min_y;
+    double max_x;
+    double max_y;
+
+    // Find bounds for grid.
+    min_x = points[0].x;
+    min_y = points[0].y;
+    max_x = points[0].x;
+    max_y = points[0].y;
+    for (int i = 1; i < N; i++)
+    {
+        // Update min bounds if needed.
+        if (points[i].x < min_x)
+        {
+            min_x = points[i].x;
+        }
+        if (points[i].y < min_y)
+        {
+            min_y = points[i].y;
+        }
+        // Update max bounds if needed.
+        if (points[i].x > max_x)
+        {
+            max_x = points[i].x;
+        }
+        if (points[i].y > max_y)
+        {
+            max_y = points[i].y;
+        }
+    }
 }
 
 void create_points(struct point *points)

--- a/dbscan.c
+++ b/dbscan.c
@@ -408,8 +408,13 @@ void dense_box(void *args)
             continue;
         }
 
-        // Update arguments for merge_dense_boxes.
+        // Label all points in this dense box with label.
         label += 1;
+        args_label_points.indices = G[i].points;
+        args_label_points.label = label;
+        label_points((void *)&args_label_points);
+
+        // Update arguments for merge_dense_boxes.
         args_merge_dense_boxes.focal = i;
         args_merge_dense_boxes.label = label;
         
@@ -420,11 +425,6 @@ void dense_box(void *args)
         {
             continue;
         }
-
-        // Label all points in this dense box with label.
-        args_label_points.indices = G[i].points;
-        args_label_points.label = label;
-        label_points((void *)&args_label_points);
 
         // Queue merged dense boxes.
         for (j = 0; j < merged_count; j++)

--- a/dbscan.c
+++ b/dbscan.c
@@ -178,10 +178,18 @@ void dense_box(void *args)
     G_x = (max_x - min_x) / cell_length;
     G_y = (max_y - min_y) / cell_length;
     
-    // Grid.
-    int *G[G_x][G_y];
+    // Grid whose cells are potential dense boxes.
+    cvector_vector_type(int) G[G_x][G_y];
 
-    // TODO: Assign each point to a cell.
+    // Assign each point to a cell in grid.
+    int x_index = 0;
+    int y_index = 0;
+    for (int i = 0; i < 10; i++)
+    {
+        x_index = (points[i].x - min_x) / cell_length;
+        y_index = (points[i].y - min_x) / cell_length;
+        cvector_push_back(G[x_index][y_index], i);
+    }
 
     // TODO: Merge dense boxes.
 }
@@ -196,8 +204,6 @@ void dbscan(void *args)
     double epsilon;
     int label;
     int min_points;
-    // Reusable; holds indices from get_neighbors.
-    int neighbors[N];
     struct point *points;
     // Seed set.
     int S[N*N];
@@ -243,12 +249,17 @@ void dbscan(void *args)
         label += 1;
         points[i].label = label;
 
-        // Loop through S; note that S_count may increase during iteration.
+        // Iterator.
         int j = 0;
+        int neighbor_count;
+        // Holds indices from get_neighbors.
+        int neighbors[N];
+        // The points index of seed in iteration below.
+        int s;
+        // Loop through S; note that S_count may increase during iteration.
         while (j < S_count)
         {
-            // The points index of the seed in this iteration.
-            int s = S[j];
+            s = S[j];
             
             // Increment j to show we've visited this seed.
             j += 1;
@@ -283,7 +294,7 @@ void dbscan(void *args)
                 .points = points
             };
 
-            int neighbor_count = get_neighbors((void *)&args);
+            neighbor_count = get_neighbors((void *)&args);
 
             if (neighbor_count < min_points)
             {

--- a/dbscan.c
+++ b/dbscan.c
@@ -1,9 +1,11 @@
+#include "cvector.h"
 #include <math.h> // sqrt
 #include <stdbool.h> // bool
 #include <stdio.h> // FILE
 #include <stdlib.h> // RAND_MAX
 
 // The number of points to generate; do not exceed 2,147,483,647 as int is being used.
+#define CVECTOR_LOGARITHMIC_GROWTH
 #define N 1000
 #define NOISE 0
 #define UNDEFINED -1


### PR DESCRIPTION
The dense box algorithm divides the data set into uniform-sized cells of a grid. It then determines which cells are dense boxes--uphold the minPts condition--and merges them to form clusters. All this to avoid distance calculations.